### PR TITLE
[FIX] Route and Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     container_name: redis
     volumes:
       - redis_data:/data
-      - redis.conf:/app/redis.conf
+      - ./redis.conf:/app/redis.conf
     command: ["redis-server", "/app/redis.conf"]
     ports:
       - "6379:6379"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
 
     // build our application with a route
     let app = Router::new()
-        .route("/:uuid", get(redirect))
+        .route("/short/:uuid", get(redirect))
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
         .leptos_routes(&leptos_options, routes, App)
         .fallback(file_and_error_handler)


### PR DESCRIPTION
Fixes:
1. Route stopping images from being served, updated to be not a root route.
2. Docker compose fix: redis volume mapping needs to be current dir